### PR TITLE
Update method for getting orders

### DIFF
--- a/modules/dal/src/db-abstraction-layer.ts
+++ b/modules/dal/src/db-abstraction-layer.ts
@@ -361,7 +361,7 @@ export class DbAbstractionLayer {
       }
     };
     console.log(queryObj);
-    return this.connector.requestData(esIndex, 'orders', queryObj);
+    return this.connector.requestFullData(esIndex, 'orders', queryObj);
   }
 
   /**


### PR DESCRIPTION
If there no results for query selection, requestData will not emit next result. Changing invocation of connector method from  requestData to requestFullData fixes that problem. Now we expect result from elasticsearch. 